### PR TITLE
CPU使用率軽減

### DIFF
--- a/Project/Codeer.Friendly.Windows/Inside/SystemStarterInApp.cs
+++ b/Project/Codeer.Friendly.Windows/Inside/SystemStarterInApp.cs
@@ -106,7 +106,13 @@ namespace Codeer.Friendly.Windows.Inside
                 EventHandler appExit = new EventHandler(delegate { NativeMethods.PostMessage(controlWindowHandle, NativeMethods.WM_QUIT, IntPtr.Zero, IntPtr.Zero); });
                 Application.ApplicationExit += appExit;
                 Debug.Trace("Success in App.");
-                var windowProcess = Process.GetProcessById(windowProcessId);
+                Process windowProcess = null;
+                try
+                {
+                    windowProcess = Process.GetProcessById(windowProcessId);
+                }
+                catch {}
+
                 while (windowProcess != null)
                 {
                     //通信プロセスが消えたら終わり

--- a/Project/Codeer.Friendly.Windows/Inside/SystemStarterInApp.cs
+++ b/Project/Codeer.Friendly.Windows/Inside/SystemStarterInApp.cs
@@ -11,11 +11,11 @@ using System.Collections.Generic;
 
 namespace Codeer.Friendly.Windows.Inside
 {
-    /// <summary>
-    /// Windowsアプリケーション操作開始クラス。
-    /// </summary>
-    public static class SystemStarterInApp
-    {
+	/// <summary>
+	/// Windowsアプリケーション操作開始クラス。
+	/// </summary>
+	public static class SystemStarterInApp
+	{
         /// <summary>
         /// ウィンドウハンドル通知メッセージ。
         /// </summary>
@@ -46,20 +46,20 @@ namespace Codeer.Friendly.Windows.Inside
         /// <param name="terminalWindow">端末ウィンドウ。</param>
         public static void StartCore(IntPtr terminalWindow)
         {
-            //コントロールスレッド終了管理スレッド
+			//コントロールスレッド終了管理スレッド
             //システムに負荷をかけない程度で端末プロセス、コントローススレッド、メインスレッドを監視する
-            new Thread((ThreadStart)delegate
-            {
+			new Thread((ThreadStart)delegate
+			{
                 Debug.Trace("Start waiting thread.");
 
                 //コントロールウィンドウのハンドル格納用
                 object sync = new object();
                 IntPtr controlWindowHandle = IntPtr.Zero;
 
-                //コントロールスレッド起動
+				//コントロールスレッド起動
                 //処理に対して素早く対応するためGetMessageを使用する
-                Thread controlThread = new Thread((ThreadStart)delegate
-                {
+				Thread controlThread = new Thread((ThreadStart)delegate
+				{
                     using (SystemControlWindowInApp window = new SystemControlWindowInApp())
                     {
                         NativeMethods.MSG msg = new NativeMethods.MSG();
@@ -77,21 +77,21 @@ namespace Codeer.Friendly.Windows.Inside
                             NativeMethods.DispatchMessage(ref msg);
                         }
                     }
-                });
-                controlThread.Start();
+				});
+				controlThread.Start();
 
-                //ウィンドウハンドル生成待ち
-                while (true)
-                {
-                    lock (sync)
-                    {
-                        if (controlWindowHandle != IntPtr.Zero)
-                        {
-                            break;
-                        }
-                    }
+				//ウィンドウハンドル生成待ち
+				while (true)
+				{
+					lock (sync)
+					{
+						if (controlWindowHandle != IntPtr.Zero)
+						{
+							break;
+						}
+					}
                     Thread.Sleep(10);
-                }
+				}
 
                 Debug.Trace("Control Window Created.");
 
@@ -122,15 +122,15 @@ namespace Codeer.Friendly.Windows.Inside
                         break;
                     }
 
-                    Thread.Sleep(200);
-                }
+					Thread.Sleep(200);
+				}
 
-                //コントロールスレッド終了
-                while (controlThread.IsAlive)
-                {
-                    NativeMethods.PostMessage(controlWindowHandle, NativeMethods.WM_QUIT, IntPtr.Zero, IntPtr.Zero);
-                    Thread.Sleep(10);
-                }
+				//コントロールスレッド終了
+				while (controlThread.IsAlive)
+				{
+					NativeMethods.PostMessage(controlWindowHandle, NativeMethods.WM_QUIT, IntPtr.Zero, IntPtr.Zero);
+					Thread.Sleep(10);
+				}
 
                 Application.ApplicationExit -= appExit;
 

--- a/Project/Codeer.Friendly.Windows/Inside/SystemStarterInApp.cs
+++ b/Project/Codeer.Friendly.Windows/Inside/SystemStarterInApp.cs
@@ -106,17 +106,12 @@ namespace Codeer.Friendly.Windows.Inside
                 EventHandler appExit = new EventHandler(delegate { NativeMethods.PostMessage(controlWindowHandle, NativeMethods.WM_QUIT, IntPtr.Zero, IntPtr.Zero); });
                 Application.ApplicationExit += appExit;
                 Debug.Trace("Success in App.");
-				while (true)
-				{
+                var windowProcess = Process.GetProcessById(windowProcessId);
+                while (windowProcess != null)
+                {
                     //通信プロセスが消えたら終わり
-                    try
-                    {
-                        if (Process.GetProcessById(windowProcessId) == null)
-                        {
-                            break;
-                        }
-                    }
-                    catch
+                    windowProcess.Refresh();
+                    if (windowProcess.HasExited)
                     {
                         break;
                     }

--- a/Project/Codeer.Friendly.Windows/Inside/SystemStarterInApp.cs
+++ b/Project/Codeer.Friendly.Windows/Inside/SystemStarterInApp.cs
@@ -11,11 +11,11 @@ using System.Collections.Generic;
 
 namespace Codeer.Friendly.Windows.Inside
 {
-	/// <summary>
-	/// Windowsアプリケーション操作開始クラス。
-	/// </summary>
-	public static class SystemStarterInApp
-	{
+    /// <summary>
+    /// Windowsアプリケーション操作開始クラス。
+    /// </summary>
+    public static class SystemStarterInApp
+    {
         /// <summary>
         /// ウィンドウハンドル通知メッセージ。
         /// </summary>
@@ -46,20 +46,20 @@ namespace Codeer.Friendly.Windows.Inside
         /// <param name="terminalWindow">端末ウィンドウ。</param>
         public static void StartCore(IntPtr terminalWindow)
         {
-			//コントロールスレッド終了管理スレッド
+            //コントロールスレッド終了管理スレッド
             //システムに負荷をかけない程度で端末プロセス、コントローススレッド、メインスレッドを監視する
-			new Thread((ThreadStart)delegate
-			{
+            new Thread((ThreadStart)delegate
+            {
                 Debug.Trace("Start waiting thread.");
 
                 //コントロールウィンドウのハンドル格納用
                 object sync = new object();
                 IntPtr controlWindowHandle = IntPtr.Zero;
 
-				//コントロールスレッド起動
+                //コントロールスレッド起動
                 //処理に対して素早く対応するためGetMessageを使用する
-				Thread controlThread = new Thread((ThreadStart)delegate
-				{
+                Thread controlThread = new Thread((ThreadStart)delegate
+                {
                     using (SystemControlWindowInApp window = new SystemControlWindowInApp())
                     {
                         NativeMethods.MSG msg = new NativeMethods.MSG();
@@ -77,21 +77,21 @@ namespace Codeer.Friendly.Windows.Inside
                             NativeMethods.DispatchMessage(ref msg);
                         }
                     }
-				});
-				controlThread.Start();
+                });
+                controlThread.Start();
 
-				//ウィンドウハンドル生成待ち
-				while (true)
-				{
-					lock (sync)
-					{
-						if (controlWindowHandle != IntPtr.Zero)
-						{
-							break;
-						}
-					}
+                //ウィンドウハンドル生成待ち
+                while (true)
+                {
+                    lock (sync)
+                    {
+                        if (controlWindowHandle != IntPtr.Zero)
+                        {
+                            break;
+                        }
+                    }
                     Thread.Sleep(10);
-				}
+                }
 
                 Debug.Trace("Control Window Created.");
 
@@ -106,13 +106,7 @@ namespace Codeer.Friendly.Windows.Inside
                 EventHandler appExit = new EventHandler(delegate { NativeMethods.PostMessage(controlWindowHandle, NativeMethods.WM_QUIT, IntPtr.Zero, IntPtr.Zero); });
                 Application.ApplicationExit += appExit;
                 Debug.Trace("Success in App.");
-                Process windowProcess = null;
-                try
-                {
-                    windowProcess = Process.GetProcessById(windowProcessId);
-                }
-                catch {}
-
+                using (Process windowProcess = GetProcessById(windowProcessId))
                 while (windowProcess != null)
                 {
                     //通信プロセスが消えたら終わり
@@ -128,21 +122,34 @@ namespace Codeer.Friendly.Windows.Inside
                         break;
                     }
 
-					Thread.Sleep(200);
-				}
+                    Thread.Sleep(200);
+                }
 
-				//コントロールスレッド終了
-				while (controlThread.IsAlive)
-				{
-					NativeMethods.PostMessage(controlWindowHandle, NativeMethods.WM_QUIT, IntPtr.Zero, IntPtr.Zero);
-					Thread.Sleep(10);
-				}
+                //コントロールスレッド終了
+                while (controlThread.IsAlive)
+                {
+                    NativeMethods.PostMessage(controlWindowHandle, NativeMethods.WM_QUIT, IntPtr.Zero, IntPtr.Zero);
+                    Thread.Sleep(10);
+                }
 
                 Application.ApplicationExit -= appExit;
 
                 //メモリ解放
                 GC.Collect();
             }).Start();
-		}
-	}
+        }
+
+        private static Process GetProcessById(int id)
+        {
+            Process process = null;
+
+            try
+            {
+                process = Process.GetProcessById(id);
+            }
+            catch { }
+
+            return process;
+        }
+    }
 }


### PR DESCRIPTION
```csharp
var app = new WindowsAppFriend(process);
```
のようにプロセスにアタッチすると、何も実行していなくても操作対象プロセスのCPU使用率が高くなってしまいます。
（環境にもよりますが、数%～10数%程度）

アタッチ前
![image](https://user-images.githubusercontent.com/6694347/61519483-fbc5fd00-aa46-11e9-86a9-12c8efaada1a.png)

アタッチ後
![image](https://user-images.githubusercontent.com/6694347/61519478-f8327600-aa46-11e9-8b29-580c2eb2f4ec.png)


プロセスの監視方法を変更したところ0～1%程度で安定するようになりました。
ご検討お願いします。