### PR TITLE
CPU使用率の改善

### DIFF
--- a/Project/Codeer.Friendly.Windows/Inside/SystemStarterInApp.cs
+++ b/Project/Codeer.Friendly.Windows/Inside/SystemStarterInApp.cs
@@ -106,17 +106,12 @@ namespace Codeer.Friendly.Windows.Inside
                 EventHandler appExit = new EventHandler(delegate { NativeMethods.PostMessage(controlWindowHandle, NativeMethods.WM_QUIT, IntPtr.Zero, IntPtr.Zero); });
                 Application.ApplicationExit += appExit;
                 Debug.Trace("Success in App.");
-				while (true)
-				{
+                using (Process windowProcess = GetProcessById(windowProcessId))
+                while (windowProcess != null)
+                {
                     //通信プロセスが消えたら終わり
-                    try
-                    {
-                        if (Process.GetProcessById(windowProcessId) == null)
-                        {
-                            break;
-                        }
-                    }
-                    catch
+                    windowProcess.Refresh();
+                    if (windowProcess.HasExited)
                     {
                         break;
                     }
@@ -143,5 +138,18 @@ namespace Codeer.Friendly.Windows.Inside
                 GC.Collect();
             }).Start();
 		}
+
+        private static Process GetProcessById(int id)
+        {
+            Process process = null;
+
+            try
+            {
+                process = Process.GetProcessById(id);
+            }
+            catch { }
+
+            return process;
+        }
 	}
 }


### PR DESCRIPTION
```csharp
var app = new WindowsAppFriend(process);
```
のようにプロセスにアタッチすると、何も実行していなくても操作対象プロセスのCPU使用率が高くなってしまいます。
（環境にもよりますが、数%～10数%程度）

アタッチ前
![image](https://user-images.githubusercontent.com/6694347/61519483-fbc5fd00-aa46-11e9-86a9-12c8efaada1a.png)

アタッチ後
![image](https://user-images.githubusercontent.com/6694347/61519478-f8327600-aa46-11e9-8b29-580c2eb2f4ec.png)


プロセスの監視方法を変更したところ0～1%程度で安定するようになりました。
ご検討お願いします。